### PR TITLE
refactor: remove devshell; add formatter; cleanup

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,8 +3,12 @@
     "bited-utils": {
       "inputs": {
         "devshell": "devshell",
-        "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs_2",
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "systems": "systems"
       },
       "locked": {
@@ -39,45 +43,11 @@
         "type": "github"
       }
     },
-    "devshell_2": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1741473158,
-        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1743550720,
@@ -109,88 +79,27 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1743296961,
-        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib_2": {
-      "locked": {
-        "lastModified": 1743296961,
-        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1744932701,
         "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
-        "owner": "NixOS",
+        "owner": "nixos",
         "repo": "nixpkgs",
         "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "nixos",
         "ref": "nixos-unstable",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1722073938,
-        "narHash": "sha256-OpX0StkL8vpXyWOGUD6G+MA26wAXK6SpT94kLJXo6B4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e36e9f57337d0ff0cf77aceb58af4c805472bfae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixpkgs-unstable",
-        "type": "indirect"
       }
     },
     "root": {
       "inputs": {
         "bited-utils": "bited-utils",
-        "devshell": "devshell_2",
-        "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs_4",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs_2",
         "systems": "systems_2"
       }
     },
@@ -218,8 +127,9 @@
         "type": "github"
       },
       "original": {
-        "id": "systems",
-        "type": "indirect"
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,25 +2,31 @@
   description = "A versatile bitmap font with an organic flair";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixpkgs-unstable";
-    systems.url = "systems";
-    flake-parts.url = "github:hercules-ci/flake-parts";
-    devshell.url = "github:numtide/devshell";
-    bited-utils.url = "github:molarmanful/bited-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+    bited-utils = {
+      url = "github:molarmanful/bited-utils";
+      inputs = {
+	nixpkgs.follows = "nixpkgs";
+	flake-parts.follows = "flake-parts";
+      };
+    };
   };
 
   outputs =
     inputs@{ systems, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
-        inputs.devshell.flakeModule
         inputs.bited-utils.flakeModule
       ];
       systems = import systems;
       perSystem =
-        { config, pkgs, ... }:
+        { config, pkgs, self', ... }:
         {
-
           bited-utils = {
             name = "kirsch";
             version = builtins.readFile ./VERSION;
@@ -37,46 +43,33 @@
               };
           };
 
-          devshells.default = {
-
-            commands = with pkgs; [
-              {
-                package = nil;
-                category = "lsp";
-              }
-              {
-                package = nixd;
-                category = "lsp";
-              }
-              {
-                package = nixfmt-rfc-style;
-                category = "formatter";
-              }
-              {
-                package = statix;
-                category = "linter";
-              }
-              {
-                package = deadnix;
-                category = "linter";
-              }
-              { package = taplo; }
-              {
-                package = marksman;
-                category = "lsp";
-              }
-              {
-                package = mdformat;
-                category = "formatter";
-              }
-              { package = config.bited-utils.bited-clr; }
-            ];
-
-            packages = with pkgs; [
-              python313Packages.mdformat-gfm
-              python313Packages.mdformat-gfm-alerts
-            ];
+          devShells.default = pkgs.mkShell {
+	    packages = builtins.attrValues {
+	      inherit (pkgs) nil nixd nixfmt-rfc-style statix deadnix taplo marksman mdformat;
+	      inherit (pkgs.python3Packages) mdformat-gfm mdformat-gfm-alerts;
+	      inherit (config.bited-utils) bited-clr;
+	    };
+	    shellHook = ''
+	      echo -e "\e[31m"
+	      ${builtins.concatStringsSep "\n" [
+		"echo 'welcome to the development shell!\n'"
+		"echo 'general commands: taplo bited-clr'"
+		"echo 'lsps: marksman nixd nil'"
+		"echo 'formatters: nixfmt-rfc-style mdformat'"
+		"echo 'linters: statix deadnix'"
+	      ]}
+              echo -e "\e[0m"
+	    '';
           };
+
+	  formatter = pkgs.writeShellApplication {
+	    name = "linter";
+	    runtimeInputs = self'.devShells.default.nativeBuildInputs;
+	    text = ''
+	      find . -iname "*.nix" -exec nixfmt {} + \; -exec deadnix -e {} + \; -exec statix fix {} \;
+              find . -iname "*.md" -exec mdformat {} + \;
+	    '';
+	  };
         };
     };
 }


### PR DESCRIPTION
## Does this break anything?

I don't think it should.

## What does this change/add/delete?

`pkgs.mkShell` is a healthier way to create a nix shell with your chosen programs and shell hooks. `devshell` isn't really needed in this case since you can reasonably achieve everything here by adding the shell hook and the packages to `pkgs.mkShell` while also making the flake needlessly larger.

I also added a formatter (with some probably devilish tricks) to format the flake without needing to use treefmt or other unneeded tree formatting solutions.

I additionally reworked the inputs a small fraction to reduce the size of the flake (using follows consistently for example).

## Do I intend to add more commits to this PR?

No, not really.